### PR TITLE
Fixing Makefile linking order for StepperMotorTest.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all:
 	g++ -std=c++11 -c *.cpp
+#	g++ -std=c++11 -c PWM.cpp
+#	g++ -std=c++11 -c Adafruit_MotorHAT.cpp
 	ar cr AdafruitStepperMotorHAT.a Adafruit_MotorHAT.o PWM.o
-	g++ -std=c++11 -o StepperMotorTest -lwiringPi StepperMotorTest.cpp AdafruitStepperMotorHAT.a
+	g++ -std=c++11 -o StepperMotorTest StepperMotorTest.cpp AdafruitStepperMotorHAT.a -lwiringPi -lpthread -lcrypt -lrt
 
 clean:
 	rm -rf StepperMotorTest *.a *.o
-
+	rm -rf StepperMotorTest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 all:
 	g++ -std=c++11 -c *.cpp
-#	g++ -std=c++11 -c PWM.cpp
-#	g++ -std=c++11 -c Adafruit_MotorHAT.cpp
 	ar cr AdafruitStepperMotorHAT.a Adafruit_MotorHAT.o PWM.o
 	g++ -std=c++11 -o StepperMotorTest StepperMotorTest.cpp AdafruitStepperMotorHAT.a -lwiringPi -lpthread -lcrypt -lrt
 


### PR DESCRIPTION
The fix also includes libraries required by the latest wiringPi